### PR TITLE
BUG: fix build errors after renaming file

### DIFF
--- a/TorchIOTransforms/CMakeLists.txt
+++ b/TorchIOTransforms/CMakeLists.txt
@@ -9,7 +9,7 @@ set(MODULE_PYTHON_SCRIPTS
   ${MODULE_NAME}Lib/HistogramStandardization
   ${MODULE_NAME}Lib/RandomAffine
   ${MODULE_NAME}Lib/RandomBiasField
-  ${MODULE_NAME}Lib/RandomDownsample
+  ${MODULE_NAME}Lib/RandomAnisotropy
   ${MODULE_NAME}Lib/RandomElasticDeformation
   ${MODULE_NAME}Lib/RandomGhosting
   ${MODULE_NAME}Lib/RandomMotion


### PR DESCRIPTION
Slicer extension doesn't build successfully:

http://slicer.cdash.org/viewConfigure.php?buildid=2087578

ref: https://github.com/fepegar/SlicerTorchIO/commit/bc20c36d97313cf97435985dfa38938b759ef182